### PR TITLE
Update `basemap` from `1.3.1` to `1.3.2`

### DIFF
--- a/recipe/build-basemap.sh
+++ b/recipe/build-basemap.sh
@@ -9,6 +9,7 @@ export GEOS_DIR=$PREFIX
 case $PKG_NAME in
 
     basemap)
+        rm -f packages/basemap/pyproject.toml
         $PYTHON -m pip install packages/basemap --no-deps --ignore-installed -vvv
         ;;
 

--- a/recipe/install_numpy_override.patch
+++ b/recipe/install_numpy_override.patch
@@ -1,0 +1,11 @@
+--- basemap-1.3.2-orig/packages/basemap/requirements.txt	2022-02-10 07:33:34.000000000 -0700
++++ basemap-1.3.2/packages/basemap/requirements.txt	2022-02-16 15:57:10.000000000 -0700
+@@ -9,7 +9,7 @@
+ numpy >= 1.15, < 1.17; python_version == "3.4"
+ numpy >= 1.16, < 1.19; python_version == "3.5"
+ numpy >= 1.16, < 1.20; python_version == "3.6"
+-numpy >= 1.21, < 1.23; python_version >= "3.7"
++numpy >= 1.19, < 1.23; python_version >= "3.7"
+ 
+ cycler < 0.11; python_version == "3.2"
+ pyparsing >= 1.5, < 2.4.1; python_version == "2.6"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,9 @@ build:
 
 requirements:
   build:
+    - python
     - m2-patch  # [win]
-    - patch  # [not win]
+    - patch     # [not win]
 
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,14 +17,11 @@ build:
   number: {{ build_number }}
   skip: True  # [s390x]  Missing dependencies.
   skip: True  # [win32]  Missing dependencies in win32 arch and not expecting they will be updated.
-  skip: True  # [py<38]  Dependencies require 3.8+
 
 requirements:
   build:
-    - python
     - m2-patch  # [win]
     - patch     # [not win]
-
 
 outputs:
 
@@ -32,6 +29,7 @@ outputs:
     script: build-basemap.sh  # [not win]  This script will delete `pyproject.toml`. Remove ASAP.
     script: bld-basemap.bat   # [win]
     build:
+      skip: True  # [py<38]  Dependencies require 3.8+
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.1" %}
+{% set version = "1.3.2" %}
 {% set build_number = "0" %}
 
 package:
@@ -7,10 +7,11 @@ package:
 
 source:
   url: https://github.com/matplotlib/basemap/archive/v{{ version }}.tar.gz
-  sha256: 8f4ed7d5736711ba2b413e5fe038d4349d35eb3f28cba836094b6cca5f0a634f
+  sha256: c35aa397be4de342a3078ec089094531609712abd78e3d11b92d792974fd8141
   patches:
     # Update messages regarding installation of `basemap-data-hires`.
     - install_hires_instructions.patch
+    - install_numpy_override.patch         # <--- This is a horible hack. Remove ASAP.
 
 build:
   number: {{ build_number }}
@@ -27,7 +28,7 @@ requirements:
 outputs:
 
   - name: basemap
-    script: build-basemap.sh  # [not win]
+    script: build-basemap.sh  # [not win]  This script will delete `pyproject.toml`. Remove ASAP.
     script: bld-basemap.bat   # [win]
     build:
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.3.2" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: basemap-split


### PR DESCRIPTION
# Changes

- Update from `1.3.1` to `1.3.2`.
- Add patch to workaround Basemap changes in dependencies.

NOTE: `linux-s390x` architecture fails due to missing dependencies.

# Review Info

## Changes

https://github.com/matplotlib/basemap/blob/v1.3.2/CHANGELOG.md

2 important items:
- CVE fixes (note that we are working around this issue)
- Removal of deprecation notices

## Issues

https://github.com/matplotlib/basemap/issues

There are plenty of issues, but I dont' see any obvious regressions that affect us.

## Pins

https://github.com/pyproj4/pyproj/blob/48d922ad57316eab45d15ccfe41595c1e5e97039/setup.cfg#L38
pyproj dependency requires `py>=3.8`

https://github.com/matplotlib/basemap/blob/v1.3.2/packages/basemap/requirements.txt
numpy, matplotlib, pyproj, pyshp


# Clossing Comments

Basic testing works.