### PR TITLE
update to 1.3.6 for python 3.11

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,2 @@
+echo "nothing todo for base ..."
+exit /b 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,5 @@
+#!/bin/base
+
+echo "nothing to do in base ..."
+exit 0
+

--- a/recipe/install_numpy_override.patch
+++ b/recipe/install_numpy_override.patch
@@ -1,11 +1,15 @@
---- basemap-1.3.2-orig/packages/basemap/requirements.txt	2022-02-10 07:33:34.000000000 -0700
-+++ basemap-1.3.2/packages/basemap/requirements.txt	2022-02-16 15:57:10.000000000 -0700
-@@ -9,7 +9,7 @@
+Index: work_failed_provide/packages/basemap/requirements.txt
+===================================================================
+--- work_failed_provide.orig/packages/basemap/requirements.txt
++++ work_failed_provide/packages/basemap/requirements.txt
+@@ -7,8 +7,8 @@ numpy >= 1.11, < 1.12; python_version ==
  numpy >= 1.15, < 1.17; python_version == "3.4"
  numpy >= 1.16, < 1.19; python_version == "3.5"
- numpy >= 1.16, < 1.20; python_version == "3.6"
--numpy >= 1.21, < 1.23; python_version >= "3.7"
-+numpy >= 1.19, < 1.23; python_version >= "3.7"
+ numpy >= 1.19, < 1.20; python_version == "3.6"
+-numpy >= 1.21, < 1.22; python_version == "3.7"
+-numpy >= 1.22, < 1.24; python_version >= "3.8"
++numpy >= 1.19, < 1.23; python_version == "3.7"
++numpy >= 1.19, < 1.24; python_version >= "3.8"
  
  cycler < 0.11; python_version == "3.2"
  pyparsing >= 1.5, < 2.4.1; python_version == "2.6"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ outputs:
         - numpy 1.19  # [ppc64le and py<310]
         - geos
         - pyproj
-        - setuptools
+        - setuptools <61  # [win]
+        - setuptools      # [not win]
         - wheel
       run:
         - {{ pin_subpackage('basemap-data') }}
@@ -81,7 +82,8 @@ outputs:
       host:
         - python
         - pip
-        - setuptools
+        - setuptools <61  # [win]
+        - setuptools  # [not win]
         - wheel
       run:
         - python
@@ -102,7 +104,8 @@ outputs:
       host:
         - python
         - pip
-        - setuptools
+        - setuptools <61  # [win]
+        - setuptools  # [not win]
         - wheel
       run:
         - {{ pin_subpackage('basemap-data') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - patch     # [not win]
 
 outputs:
-
   - name: basemap
     script: build-basemap.sh  # [not win]  This script will delete `pyproject.toml`. Remove ASAP.
     script: bld-basemap.bat   # [win]
@@ -37,8 +36,8 @@ outputs:
         - python
         - pip
         - cython >=0.29,<3.1
-        - numpy 1.21  # [not ppc64le]
-        - numpy 1.19  # [ppc64le]
+        - numpy 1.21  # [not ppc64le or py>=310]
+        - numpy 1.19  # [ppc64le and py<310]
         - geos
         - pyproj
         - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: {{ build_number }}
-  skip: True  # [py<37]
+  skip: True  # [py<37 or py>310]
   skip: True  # [s390x]  Missing dependencies.
   skip: True  # [win32]  Missing dependencies in win32 arch and not expecting they will be updated.
 
@@ -57,6 +57,7 @@ outputs:
       requires:
         - pip
         - {{ pin_subpackage('basemap-data') }}
+        - python
       commands:
         - pip check
         - python -c "from mpl_toolkits.basemap import Basemap"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ outputs:
         - pip
         - cython >=0.29,<3.1
         - numpy 1.21  # [not ppc64le or py==310]
-        - numpy       # [not ppc64le or py>=311]
+        - numpy 1.22  # [not ppc64le or py>=311]
         - numpy 1.19  # [ppc64le and py<310]
         - geos
         - pyproj

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,8 @@ outputs:
         - python
         - pip
         - cython >=0.29,<3.1
-        - numpy 1.21  # [not ppc64le or py>=310]
+        - numpy 1.21  # [not ppc64le or py==310]
+        - numpy       # [not ppc64le or py>=311]
         - numpy 1.19  # [ppc64le and py<310]
         - geos
         - pyproj

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ outputs:
         - python
         - pip
         - cython >=0.29,<3.1
-        - numpy 1.21  # [not ppc64le or py==310]
+        - numpy 1.21  # [(py<310 and not ppc64le) or py==310]
         - numpy 1.22  # [not ppc64le or py>=311]
         - numpy 1.19  # [ppc64le and py<310]
         - geos

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: {{ build_number }}
-  skip: True  # [py<37 or py>310]
+  skip: True  # [py<37]
   skip: True  # [s390x]  Missing dependencies.
   skip: True  # [win32]  Missing dependencies in win32 arch and not expecting they will be updated.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.2" %}
+{% set version = "1.3.6" %}
 {% set build_number = "1" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/matplotlib/basemap/archive/v{{ version }}.tar.gz
-  sha256: c35aa397be4de342a3078ec089094531609712abd78e3d11b92d792974fd8141
+  sha256: 42adbd039b4afbe93ca2fa32cfab456d4fd590cb8ed1c28e4aa94dcb957b58ac
   patches:
     # Update messages regarding installation of `basemap-data-hires`.
     - install_hires_instructions.patch
@@ -15,6 +15,7 @@ source:
 
 build:
   number: {{ build_number }}
+  skip: True  # [py<37]
   skip: True  # [s390x]  Missing dependencies.
   skip: True  # [win32]  Missing dependencies in win32 arch and not expecting they will be updated.
 
@@ -28,8 +29,6 @@ outputs:
   - name: basemap
     script: build-basemap.sh  # [not win]  This script will delete `pyproject.toml`. Remove ASAP.
     script: bld-basemap.bat   # [win]
-    build:
-      skip: True  # [py<38]  Dependencies require 3.8+
     requirements:
       build:
         - {{ compiler('c') }}
@@ -38,8 +37,8 @@ outputs:
         - python
         - pip
         - cython >=0.29,<3.1
-        - numpy >=1.21  # [not ppc64le]
-        - numpy >=1.19  # [ppc64le]
+        - numpy 1.21  # [not ppc64le]
+        - numpy 1.19  # [ppc64le]
         - geos
         - pyproj
         - setuptools
@@ -49,10 +48,9 @@ outputs:
         - python
         - {{ pin_compatible('numpy') }}
         - {{ pin_compatible('geos') }}
-        - matplotlib-base >=1.5,!=3.0.1
-        - pyproj >=1.9.3,<3.4
-        - pyshp >=1.2.0,<2.2
-        - six >=1.10,<1.16
+        - matplotlib-base >=1.5,!=3.0.1,<3.7
+        - pyproj >=1.9.3,<3.5.0
+        - pyshp >=1.2.0,<2.4
     test:
       imports:
         - mpl_toolkits.basemap
@@ -79,8 +77,6 @@ outputs:
   - name: basemap-data
     script: build-basemap.sh  # [not win]
     script: bld-basemap.bat   # [win]
-    build:
-      noarch: python
     requirements:
       host:
         - python
@@ -88,7 +84,7 @@ outputs:
         - setuptools
         - wheel
       run:
-        - python >=3.6
+        - python
     about:
       home: https://matplotlib.org/basemap
       license: LGPL-3.0-or-later
@@ -102,8 +98,6 @@ outputs:
   - name: basemap-data-hires
     script: build-basemap.sh  # [not win]
     script: bld-basemap.bat   # [win]
-    build:
-      noarch: python
     requirements:
       host:
         - python
@@ -112,7 +106,7 @@ outputs:
         - wheel
       run:
         - {{ pin_subpackage('basemap-data') }}
-        - python >=3.6
+        - python
     about:
       home: https://matplotlib.org/basemap
       license: LGPL-3.0-or-later
@@ -121,9 +115,6 @@ outputs:
       summary: Plot on map projections (with coastlines and political boundaries) using matplotlib.
       dev_url: https://github.com/matplotlib/basemap
       doc_url: https://matplotlib.org/basemap/
-      doc_source_url: https://github.com/matplotlib/basemap/blob/v{{ version }}/packages/basemap/doc/index.rst
-
-
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,8 @@ outputs:
       requires:
         - pip
         - {{ pin_subpackage('basemap-data') }}
-        - python
+        - python <3.11  # [py<311]
+        - python        # [py>=311]
       commands:
         - pip check
         - python -c "from mpl_toolkits.basemap import Basemap"
@@ -88,6 +89,11 @@ outputs:
         - wheel
       run:
         - python
+    test:
+      requires:
+        - python <3.11  # [py<311]
+        - python        # [py>=311]
+
     about:
       home: https://matplotlib.org/basemap
       license: LGPL-3.0-or-later
@@ -111,6 +117,10 @@ outputs:
       run:
         - {{ pin_subpackage('basemap-data') }}
         - python
+    test:
+      requires:
+        - python <3.11  # [py<311]
+        - python        # [py>=311]
     about:
       home: https://matplotlib.org/basemap
       license: LGPL-3.0-or-later

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ outputs:
         - pip
         - cython >=0.29,<3.1
         - numpy 1.21  # [(py<310 and not ppc64le) or py==310]
-        - numpy 1.22  # [not ppc64le or py>=311]
+        - numpy 1.22  # [py>=311]
         - numpy 1.19  # [ppc64le and py<310]
         - geos
         - pyproj


### PR DESCRIPTION
* update to 1.3.6 for adding official python 3.11 support
* adjust pinnings and patch file for numpy-requirments