### PR TITLE
basemap 2.0.0 - rebuild py314

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "2.0.0" %}
-{% set build_number = "0" %}
 
 package:
   name: basemap-split
@@ -11,9 +10,11 @@ source:
   patches:
     # Update messages regarding installation of `basemap-data-hires`.
     - patches/install_hires_instructions.patch
+    # TODO: Remove this patch once new version with py314 support upstream available
+    - patches/setup_py-enable-py314.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
 
 requirements:
@@ -58,7 +59,7 @@ outputs:
         - pip check
         - python -c "from mpl_toolkits.basemap import Basemap"
         # skipping test_arcgisimage_with_cyl_using_cache due to HTTP Error 503: Service Unavailable
-        - pytest test -k "not test_arcgisimage_with_cyl_using_cache"
+        - pytest -ra -vv test -k "not test_arcgisimage_with_cyl_using_cache"
     about:
       home: https://matplotlib.org/basemap
       license: MIT

--- a/recipe/patches/setup_py-enable-py314.patch
+++ b/recipe/patches/setup_py-enable-py314.patch
@@ -1,0 +1,25 @@
+From ccee981ffe79862865663f8a949080ed2ae941fb Mon Sep 17 00:00:00 2001
+From: "Viacheslav Ch." <vchychyrko@anaconda.com>
+Date: Fri, 10 Apr 2026 18:00:46 +0300
+Subject: [PATCH] setup_py-enable-py314
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 070b495..188a92a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -208,7 +208,7 @@ setup(**{
+     "python_requires":
+         ", ".join([
+             ">=3.9",
+-            "<3.14",
++            "<3.15",
+         ]),
+     "install_requires":
+         get_content("dep/requirements.txt", splitlines=True),
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
basemap 2.0.0  - rebuild py314

**Destination channel:** Defaults

### Links

- [PKG-12128]
- dev_url:        No/tree/
- conda_forge:    https://github.com/conda-forge/basemap-feedstock
- pypi:           https://pypi.org/project/basemap/2.0.0
- pypi inspector: https://inspector.pypi.io/project/basemap/2.0.0

### Explanation of changes:

- rebuild py314


[PKG-12128]: https://anaconda.atlassian.net/browse/PKG-12128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ